### PR TITLE
Fix memory leak in IconController

### DIFF
--- a/SeaEye/controllers/SeaEyeIconController.swift
+++ b/SeaEye/controllers/SeaEyeIconController.swift
@@ -15,7 +15,8 @@ class SeaEyeIconController: NSViewController {
     var applicationStatus = SeaEyeStatus()
     var hasViewedBuilds = true
     var popover = NSPopover()
-    
+    var popoverController: SeaEyePopoverController?
+
     override init(nibName nibNameOrNil: NSNib.Name?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
@@ -48,6 +49,11 @@ class SeaEyeIconController: NSViewController {
                                                queue: OperationQueue.main,
                                                using: setGreenBuildIcon)
         
+        if let popoverController = SeaEyePopoverController(nibName: NSNib.Name(rawValue: "SeaEyePopoverController"), bundle: nil) as SeaEyePopoverController? {
+            popoverController.model = self.model
+            popoverController.applicationStatus = self.applicationStatus
+            self.popoverController = popoverController
+        }
         NSEvent.addGlobalMonitorForEvents(
             matching: [.leftMouseUp, .rightMouseUp],
             handler: closePopover
@@ -178,10 +184,6 @@ class SeaEyeIconController: NSViewController {
     
     @IBAction func openPopover(_ sender: NSButton) {
         self.setupMenuBarIcon()
-        let popoverController = SeaEyePopoverController(nibName: NSNib.Name(rawValue: "SeaEyePopoverController"), bundle: nil) as SeaEyePopoverController!
-        popoverController?.model = self.model
-        popoverController?.applicationStatus = self.applicationStatus   
-        
         if !popover.isShown {
             popover.contentViewController = popoverController
             popover.show(relativeTo: self.view.frame, of: self.view, preferredEdge: NSRectEdge.minY)


### PR DESCRIPTION
Previously, every time you click the icon SeaEye creates a new popover controller -- so memory continues to grow, every-time you show the controller.

<img width="1241" alt="screenshot 2018-06-17 at 16 27 34" src="https://user-images.githubusercontent.com/625787/41509428-596a204c-724b-11e8-9b16-d520e1c8ff19.png">

Now, we don't do that.

<img width="1187" alt="screenshot 2018-06-17 at 16 29 21" src="https://user-images.githubusercontent.com/625787/41509456-b29bcc92-724b-11e8-85aa-43c16865e6d3.png">

240MB vs 24MB