### PR TITLE
Look up latest version on github

### DIFF
--- a/SeaEye.xcodeproj/project.pbxproj
+++ b/SeaEye.xcodeproj/project.pbxproj
@@ -88,6 +88,8 @@
 		F422C54820D48CC2002A5897 /* VersionNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = F422C54720D48CC2002A5897 /* VersionNumber.swift */; };
 		F422C54920D48CDD002A5897 /* VersionNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = F422C54720D48CC2002A5897 /* VersionNumber.swift */; };
 		F422C54B20D48CF2002A5897 /* VersionNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F422C54A20D48CF2002A5897 /* VersionNumberTests.swift */; };
+		F4F1A61D20D84CD1008B8C04 /* GithubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F1A61C20D84CD1008B8C04 /* GithubClient.swift */; };
+		F4F1A61E20D84DBE008B8C04 /* GithubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F1A61C20D84CD1008B8C04 /* GithubClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -178,6 +180,7 @@
 		60F0232B1A1A95930067C0A0 /* SeaEyeUpdatesController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeaEyeUpdatesController.swift; sourceTree = "<group>"; };
 		F422C54720D48CC2002A5897 /* VersionNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionNumber.swift; sourceTree = "<group>"; };
 		F422C54A20D48CF2002A5897 /* VersionNumberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionNumberTests.swift; sourceTree = "<group>"; };
+		F4F1A61C20D84CD1008B8C04 /* GithubClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GithubClient.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -201,6 +204,7 @@
 		5394797E1FCB8C9000D6FA19 /* services */ = {
 			isa = PBXGroup;
 			children = (
+				F4F1A61C20D84CD1008B8C04 /* GithubClient.swift */,
 				539479741FCB639300D6FA19 /* CircleCIClient.swift */,
 				539479811FCB8D4C00D6FA19 /* BuildsForUser.swift */,
 				53A3BE981FD35F04006961C6 /* CircleCIDecoder.swift */,
@@ -546,6 +550,7 @@
 				5394797D1FCB8C5200D6FA19 /* CircleCIBuild.swift in Sources */,
 				60F0232C1A1A95930067C0A0 /* SeaEyeUpdatesController.swift in Sources */,
 				603314A619FDCBFD0073EAED /* CircleCIModel.swift in Sources */,
+				F4F1A61D20D84CD1008B8C04 /* GithubClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -556,6 +561,7 @@
 				5394798D1FCB909600D6FA19 /* CircleCIClient.swift in Sources */,
 				539479871FCB8EA500D6FA19 /* CircleCIBuild.swift in Sources */,
 				539479861FCB8E8F00D6FA19 /* CircleCIModel.swift in Sources */,
+				F4F1A61E20D84DBE008B8C04 /* GithubClient.swift in Sources */,
 				53A3BE9A1FD35F6B006961C6 /* CircleCIDecoder.swift in Sources */,
 				5389EF4A1FCBBA49001C0D5F /* DecodingTests.swift in Sources */,
 				F422C54B20D48CF2002A5897 /* VersionNumberTests.swift in Sources */,

--- a/SeaEye/VersionNumber.swift
+++ b/SeaEye/VersionNumber.swift
@@ -1,9 +1,18 @@
 import Foundation
 
-struct VersionNumber: Equatable, CustomStringConvertible, Comparable{
+struct VersionNumber: Equatable, CustomStringConvertible, Comparable {
     var major: Int
     var minor: Int
     var development: Bool
+
+    static func current() -> VersionNumber {
+        if let info = Bundle.main.infoDictionary as NSDictionary? {
+            if let version = info.object(forKey: "CFBundleShortVersionString") as? String {
+                return version.versionNumber()
+            }
+        }
+        return VersionNumber.init(major: 0, minor: 0, development: true)
+    }
 
     var description: String {
         var str = "\(major).\(minor)"

--- a/SeaEye/controllers/SeaEyeSettingsController.swift
+++ b/SeaEye/controllers/SeaEyeSettingsController.swift
@@ -116,10 +116,6 @@ class SeaEyeSettingsController: NSViewController {
     }
 
     fileprivate func setupVersionNumber() {
-        if let info = Bundle.main.infoDictionary as NSDictionary! {
-            if let version = info.object(forKey: "CFBundleShortVersionString") as? String {
-                versionString.stringValue = "Version \(version)"
-            }
-        }
+        versionString.stringValue = VersionNumber.current().description
     }
 }

--- a/SeaEye/controllers/SeaEyeUpdatesController.swift
+++ b/SeaEye/controllers/SeaEyeUpdatesController.swift
@@ -9,7 +9,6 @@
 import Cocoa
 
 class SeaEyeUpdatesController: NSViewController {
-
     var applicationStatus: SeaEyeStatus!
 
     @IBOutlet weak var versionLabel: NSTextField!
@@ -29,6 +28,10 @@ class SeaEyeUpdatesController: NSViewController {
     }
 
     func setup() {
+        if applicationStatus == nil {
+            return
+        }
+
         if applicationStatus.version != nil {
             changes.stringValue = applicationStatus.version!.changes
             versionLabel.stringValue = "Version \(applicationStatus.version!.latestVersion) Available"
@@ -36,9 +39,11 @@ class SeaEyeUpdatesController: NSViewController {
     }
 
     @IBAction func openUpdatesPage(_ sender: NSButton) {
+        if applicationStatus == nil {
+            return
+        }
         if applicationStatus.version != nil {
             NSWorkspace.shared.open(applicationStatus.version!.downloadUrl)
         }
     }
-
 }

--- a/SeaEye/services/CircleCIClient.swift
+++ b/SeaEye/services/CircleCIClient.swift
@@ -25,20 +25,6 @@ func circleCIurlForPath(path: String) -> URL {
     return URL(string: "https://circleci.com/api/v1.1/\(path)?circle-token=\(token)")!
 }
 
-
-struct SeaEyeVersion: Decodable {
-    let latestVersion: String
-    let downloadUrl: URL
-    let changes: String
-}
-
-func latestSeaEyeVersion(completion: ((Result<SeaEyeVersion>) -> Void)?) {
-    let url = "https://raw.githubusercontent.com/nolaneo/SeaEye/master/project_status.json"
-    let req = URLRequest(url: (URL(string: url))!)
-
-    request(req, of: SeaEyeVersion.self, completion: completion)
-}
-
 func request <T: Decodable>(_ request: URLRequest, of: T.Type, completion: ((Result<T>) -> Void)?) {
     let session = URLSession(configuration: URLSessionConfiguration.default)
 

--- a/SeaEye/services/GithubClient.swift
+++ b/SeaEye/services/GithubClient.swift
@@ -1,0 +1,49 @@
+//
+//  GithubClient.swift
+//  SeaEye
+//
+//  Created by Conor Mongey on 15/06/2018.
+//  Copyright © 2018 Nolaneo. All rights reserved.
+//
+
+import Foundation
+
+struct SeaEyeVersion: Decodable {
+    let latestVersion: String
+    let downloadUrl: URL
+    let changes: String
+}
+
+struct Release: Decodable {
+    let tagName: String
+    let prerelease: Bool
+    let draft: Bool
+    let htmlUrl: String
+    let name: String
+    let body: String
+
+    func version() -> VersionNumber {
+        return tagName.versionNumber()
+    }
+
+    func toSeaEye() -> SeaEyeVersion {
+        return SeaEyeVersion.init(latestVersion: tagName, downloadUrl: URL.init(string: htmlUrl)!, changes: body)
+    }
+}
+
+
+public class GithubClient {
+    static func latestRelease(completion: ((Result<Release>) -> Void)?) {
+        request(get(path: "releases/latest"), of: Release.self, completion: completion)
+    }
+
+    private static func get(path: String) -> URLRequest {
+        let baseURL = "api.github.com/repos/nolaneo/SeaEye"
+        let url =  URL(string: "https://\(baseURL)/\(path)")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("application/json", forHTTPHeaderField: "accept")
+        request.addValue("application/json", forHTTPHeaderField: "content-type")
+        return request
+    }
+}


### PR DESCRIPTION
Uses the GitHub release API to see what version is the latest. (currently 0.4)

I'll probably remove the `SeaEyeVersion` model in another sweep