### PR TITLE
fix: handle nil crash in Settings and LoginItems

### DIFF
--- a/SeaEye/models/Settings.swift
+++ b/SeaEye/models/Settings.swift
@@ -31,6 +31,9 @@ struct Settings: Codable {
 
     func projects() -> [ClientProject] {
         let projectNames = projectsString?.components(separatedBy: CharacterSet.whitespaces)
+        if (apiKey == nil) {
+            return []
+        }
         let client = CircleCIClient.init(apiKey: apiKey!)
         if !valid() {
             return []

--- a/SeaEye/services/ApplicationStartupManager.swift
+++ b/SeaEye/services/ApplicationStartupManager.swift
@@ -52,6 +52,9 @@ struct ApplicationStartupManager {
         let loginItems: [LSSharedFileListItem] = LSSharedFileListCopySnapshot(loginItemsRef, nil).takeRetainedValue() as! [LSSharedFileListItem]
         // swiftlint:enable force_cast
         print("There are \(loginItems.count) login items")
+        if (loginItems.last == nil) {
+            return (nil, nil)
+        }
         let lastItemRef: LSSharedFileListItem = loginItems.last!
 
         for currentItemRef in loginItems {


### PR DESCRIPTION
While trying this app out on my machine it encountered a few crashes from a clean state.  These changes handle a `nil` apiKey and `loginItems` being empty 👍 